### PR TITLE
Curl handle management.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /*
 
 !src/
-!thirdparty/
+!java9/
 
 !LICENSE.txt
 !README.MD

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ sourceSets {
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url 'https://maven.covers1624.net' }
 }
 
 configurations {
@@ -58,6 +59,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
     testImplementation 'org.nanohttpd:nanohttpd:2.3.1'
+    testImplementation 'net.covers1624:Quack:0.4.9.77'
 }
 
 def natives = [
@@ -226,8 +228,11 @@ natives.each {
     extractCurlTasks << extractCurl
 }
 
+evaluationDependsOn(":java9")
+
 jar {
     mustRunAfter("curl4j${os.capitalize()}_${arch}ReleaseSharedLibrary")
+    from project(":java9").sourceSets.main.output
     natives.each { o ->
         from(fileTree("build/libs/curl4j/shared/${o[0]}_${o[1]}/release/")) {
             into "META-INF/natives/${o[0]}/${o[1]}/"
@@ -242,6 +247,7 @@ tasks.register('jarWithLibCurl', Jar) {
     mustRunAfter("curl4j${os.capitalize()}_${arch}ReleaseSharedLibrary")
 
     from sourceSets.main.output
+    from project(":java9").sourceSets.main.output
 
     natives.each { o ->
         from(fileTree("build/libs/curl4j/shared/${o[0]}_${o[1]}/release/")) {
@@ -259,6 +265,8 @@ test {
     dependsOn("curl4j${os.capitalize()}_${arch}ReleaseSharedLibrary")
     dependsOn extractCurlTasksMap["${os}_$arch"]
 
+    classpath += project(":java9").sourceSets.main.output
+
     useJUnitPlatform()
 
     systemProperty('net.covers1624.curl4j.libcurl4j.name', file("build/libs/curl4j/shared/${os}_${arch}/release/${System.mapLibraryName('curl4j')}"))
@@ -270,6 +278,8 @@ tasks.register('testJ17', Test) {
     dependsOn("curl4j${os.capitalize()}_${arch}ReleaseSharedLibrary")
     dependsOn extractCurlTasksMap["${os}_$arch"]
 
+    classpath += project(":java9").sourceSets.main.output
+
     useJUnitPlatform()
 
     systemProperty('net.covers1624.curl4j.libcurl4j.name', file("build/libs/curl4j/shared/${os}_${arch}/release/${System.mapLibraryName('curl4j')}"))
@@ -278,6 +288,8 @@ tasks.register('testJ17', Test) {
         languageVersion = JavaLanguageVersion.of(17)
     }
 }
+
+check.dependsOn('testJ17')
 
 publishing {
     repositories {

--- a/java9/.gitignore
+++ b/java9/.gitignore
@@ -1,0 +1,5 @@
+/*
+
+!src/
+!build.gradle
+!.gitignore

--- a/java9/build.gradle
+++ b/java9/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(9)
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven { url 'https://maven.covers1624.net' }
+}
+
+dependencies {
+    implementation rootProject
+
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
+}

--- a/java9/src/main/java/net/covers1624/curl4j/util/CleaningCurlHandle.java
+++ b/java9/src/main/java/net/covers1624/curl4j/util/CleaningCurlHandle.java
@@ -1,0 +1,40 @@
+package net.covers1624.curl4j.util;
+
+import net.covers1624.curl4j.CURL;
+
+import java.lang.ref.Cleaner;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongFunction;
+
+/**
+ * A {@link CurlHandle} implementation which uses Java9+
+ * {@link Cleaner}s instead of {@link Object#finalize()}
+ * to clean up curl handles.
+ * <p>
+ * Created by covers1624 on 23/10/23.
+ */
+public class CleaningCurlHandle extends CurlHandle {
+
+    private static final Cleaner CLEANER = Cleaner.create();
+
+    public CleaningCurlHandle(long curl) {
+        this(curl, new AtomicBoolean());
+    }
+
+    private CleaningCurlHandle(long curl, AtomicBoolean cleaned) {
+        super(curl, cleaned);
+        CLEANER.register(this, () -> {
+            if (!cleaned.get()) {
+                CURL.curl_easy_cleanup(curl);
+            }
+        });
+    }
+
+    public static class Factory implements LongFunction<CurlHandle> {
+
+        @Override
+        public CurlHandle apply(long value) {
+            return new CleaningCurlHandle(value);
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,4 @@
 rootProject.name = 'curl4j'
 
+include 'java9'
+

--- a/src/main/java/net/covers1624/curl4j/util/CurlHandle.java
+++ b/src/main/java/net/covers1624/curl4j/util/CurlHandle.java
@@ -1,0 +1,39 @@
+package net.covers1624.curl4j.util;
+
+import net.covers1624.curl4j.CURL;
+
+/**
+ * A simple curl wrapper which will automatically
+ * clean up the curl handle.
+ * <p>
+ * Created by covers1624 on 20/10/23.
+ */
+public final class CurlHandle implements AutoCloseable {
+
+    public final long curl;
+
+    private boolean cleaned;
+
+    public CurlHandle(long curl) {
+        this.curl = curl;
+    }
+
+    public static ThreadLocal<CurlHandle> newThreadLocal() {
+        return ThreadLocal.withInitial(() -> new CurlHandle(CURL.curl_easy_init()));
+    }
+
+    // TODO, We can do better than this. We need a variant of CurlHandle which does not use finalize
+    //       but instead uses Java9+ Cleaners.
+    @Override
+    protected void finalize() {
+        close();
+    }
+
+    @Override
+    public void close() {
+        if (cleaned) return;
+        cleaned = true;
+
+        CURL.curl_easy_cleanup(curl);
+    }
+}

--- a/src/main/java/net/covers1624/curl4j/util/CurlHandle.java
+++ b/src/main/java/net/covers1624/curl4j/util/CurlHandle.java
@@ -2,38 +2,63 @@ package net.covers1624.curl4j.util;
 
 import net.covers1624.curl4j.CURL;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongFunction;
+
 /**
  * A simple curl wrapper which will automatically
  * clean up the curl handle.
  * <p>
  * Created by covers1624 on 20/10/23.
  */
-public final class CurlHandle implements AutoCloseable {
+public class CurlHandle implements AutoCloseable {
+
+    private static final LongFunction<CurlHandle> FACTORY = chooseFactory();
 
     public final long curl;
+    private final AtomicBoolean cleaned;
 
-    private boolean cleaned;
-
-    public CurlHandle(long curl) {
+    CurlHandle(long curl, AtomicBoolean cleaned) {
         this.curl = curl;
+        this.cleaned = cleaned;
+    }
+
+    public static CurlHandle create() {
+        return FACTORY.apply(CURL.curl_easy_init());
     }
 
     public static ThreadLocal<CurlHandle> newThreadLocal() {
-        return ThreadLocal.withInitial(() -> new CurlHandle(CURL.curl_easy_init()));
-    }
-
-    // TODO, We can do better than this. We need a variant of CurlHandle which does not use finalize
-    //       but instead uses Java9+ Cleaners.
-    @Override
-    protected void finalize() {
-        close();
+        return ThreadLocal.withInitial(CurlHandle::create);
     }
 
     @Override
     public void close() {
-        if (cleaned) return;
-        cleaned = true;
+        if (cleaned.get()) return;
+        cleaned.set(true);
 
         CURL.curl_easy_cleanup(curl);
+    }
+
+    @SuppressWarnings ("unchecked")
+    private static LongFunction<CurlHandle> chooseFactory() {
+        try {
+            Class.forName("java.lang.ref.Cleaner");
+            Class<?> clazz = Class.forName("net.covers1624.curl4j.util.CleaningCurlHandle$Factory");
+            return (LongFunction<CurlHandle>) clazz.getConstructor().newInstance();
+        } catch (Throwable ex) {
+            return FinalizingCurlHandle::new;
+        }
+    }
+
+    public static class FinalizingCurlHandle extends CurlHandle {
+
+        public FinalizingCurlHandle(long curl) {
+            super(curl, new AtomicBoolean());
+        }
+
+        @Override
+        protected void finalize() {
+            close();
+        }
     }
 }

--- a/src/test/java/net/covers1624/curl4j/util/TestCurlHandle.java
+++ b/src/test/java/net/covers1624/curl4j/util/TestCurlHandle.java
@@ -1,0 +1,24 @@
+package net.covers1624.curl4j.util;
+
+import net.covers1624.quack.util.JavaVersion;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Created by covers1624 on 23/10/23.
+ */
+public class TestCurlHandle {
+
+    @Test
+    public void testCurlHandleUsesCleaner() {
+        CurlHandle handle = CurlHandle.create();
+
+        if (JavaVersion.parse(System.getProperty("java.version")) == JavaVersion.JAVA_1_8) {
+            assertEquals(CurlHandle.FinalizingCurlHandle.class, handle.getClass());
+        } else {
+            assertNotEquals(CurlHandle.FinalizingCurlHandle.class, handle.getClass());
+        }
+    }
+}


### PR DESCRIPTION
Add some easy-to-use wrappers around curl handles which automatically cleanup the curl native resource when not in use anymore.

TODO:
- [x] Use `Cleaner` API on java 9+