### PR TITLE
fix curl_easy_getinfo_String return

### DIFF
--- a/src/main/java/net/covers1624/curl4j/CURL.java
+++ b/src/main/java/net/covers1624/curl4j/CURL.java
@@ -3154,7 +3154,8 @@ public class CURL {
             if (ret != CURLE_OK) {
                 throw new IllegalStateException("CURL error querying info: " + curl_easy_strerror(ret));
             }
-            return pointer.readUtf8Safe();
+            Pointer strPtr = pointer.readPointer();
+            return strPtr != null ? strPtr.readUtf8Safe() : null;
         }
     }
 

--- a/src/test/java/net/covers1624/curl4j/CURLTests.java
+++ b/src/test/java/net/covers1624/curl4j/CURLTests.java
@@ -57,6 +57,7 @@ public class CURLTests extends TestBase {
 
                 assertEquals(CURLE_OK, result, () -> curl_easy_strerror(result));
                 assertEquals(200, curl_easy_getinfo_long(curl, CURLINFO_RESPONSE_CODE));
+                assertEquals("127.0.0.1", curl_easy_getinfo_String(curl, CURL.CURLINFO_PRIMARY_IP));
                 assertArrayEquals(data, output.bytes());
             }
         } finally {


### PR DESCRIPTION
Fixes #18 

This was suggested by an LLM (Claude) and I have no idea if it's the proper way to handle but it works. For testing I extended `CURLTests.testDownload()` instead of creating a new one in order to not clog up the class.