### PR TITLE
Migrate to macos-15 for building.

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -64,7 +64,7 @@ jobs:
       image: alpine:3.18.5
     steps:
       - name: "Setup"
-        run: apk update && apk add openjdk8 openjdk9 openjdk17 git
+        run: apk update && apk add openjdk8 openjdk11 openjdk17 git
       - uses: actions/checkout@v4
       - name: Gradle Cache
         uses: actions/cache@v4
@@ -79,11 +79,11 @@ jobs:
       - name: "Check"
         run: |
           export JDK8=/usr/lib/jvm/java-8-openjdk/
-          export JDK9=/usr/lib/jvm/java-9-openjdk/
+          export JDK11=/usr/lib/jvm/java-11-openjdk/
           export JDK17=/usr/lib/jvm/java-17-openjdk/
           export JAVA_HOME=/usr/lib/jvm/java-8-openjdk/
           export LIBC=musl
-          ./gradlew check -si -Porg.gradle.native=false -Porg.gradle.java.installations.fromEnv=JDK8,JDK9,JDK17
+          ./gradlew check -si -Porg.gradle.native=false -Porg.gradle.java.installations.fromEnv=JDK8,JDK11,JDK17
 
   build_linux_arm64-gnu:
     runs-on: ubuntu-22.04

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -260,11 +260,11 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           architecture: 'aarch64'
-      - name: Setup Java 9 Arm64
+      - name: Setup Java 11 Arm64
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: '9'
+          distribution: 'temurin'
+          java-version: '11'
           architecture: 'aarch64'
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -83,7 +83,7 @@ jobs:
           export JDK17=/usr/lib/jvm/java-17-openjdk/
           export JAVA_HOME=/usr/lib/jvm/java-8-openjdk/
           export LIBC=musl
-          ./gradlew check -si -Porg.gradle.java.installations.fromEnv=JDK8,JDK9,JDK17
+          ./gradlew check -si -Porg.gradle.native=false -Porg.gradle.java.installations.fromEnv=JDK8,JDK9,JDK17
 
   build_linux_arm64-gnu:
     runs-on: ubuntu-22.04

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -254,6 +254,18 @@ jobs:
           path: ~/.gradle
           key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-
+      - name: Setup Java 8 Arm64
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          architecture: 'aarch64'
+      - name: Setup Java 9 Arm64
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '9'
+          architecture: 'aarch64'
       - uses: actions/download-artifact@v4
         with:
           name: macos_arm64

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -205,24 +205,43 @@ jobs:
           path: |
             native_build/install/libcurl*
 
-#  test_macos_x64:
-#    runs-on: macos-15
-#    needs: build_macos_x64
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Gradle Cache
-#        uses: actions/cache@v4
-#        with:
-#          path: ~/.gradle
-#          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-#          restore-keys: gradle-
-#      - uses: actions/download-artifact@v4
-#        with:
-#          name: macos_x64
-#          path: native_build/install/
-#      - name: "Check"
-#        run: |
-#          ./gradlew check -si
+  test_macos_x64:
+    runs-on: macos-15
+    needs: build_macos_x64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Gradle Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+      - name: Setup Java 8 x64
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          architecture: 'x64'
+      - name: Setup Java 11 x64
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          architecture: 'x64'
+      - name: Setup Java 17 x64
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          architecture: 'x64'
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos_x64
+          path: native_build/install/
+      - name: "Check"
+        run: |
+          cat /Users/runner/.m2/settings.xml
+          ./gradlew check -si
 
   build_macos_arm64:
     runs-on: macos-15
@@ -276,7 +295,7 @@ jobs:
 
   collate:
     runs-on: ubuntu-22.04
-    needs: [ build_linux_x64-gnu, test_linux_x64-gnu, build_linux_x64-musl, test_linux_x64-musl, build_linux_arm64-gnu, build_linux_arm64-musl, test_linux_arm64-gnu, build_windows_x64, test_windows_x64, build_macos_x64, build_macos_arm64, test_macos_arm64 ]
+    needs: [ build_linux_x64-gnu, test_linux_x64-gnu, build_linux_x64-musl, test_linux_x64-musl, build_linux_arm64-gnu, build_linux_arm64-musl, test_linux_arm64-gnu, build_windows_x64, test_windows_x64, build_macos_x64, test_macos_x64, build_macos_arm64, test_macos_arm64 ]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -187,7 +187,7 @@ jobs:
           ./gradlew check -si
 
   build_macos_x64:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies.
@@ -206,7 +206,7 @@ jobs:
             native_build/install/libcurl*
 
   test_macos_x64:
-    runs-on: macos-12
+    runs-on: macos-15
     needs: build_macos_x64
     steps:
       - uses: actions/checkout@v4
@@ -225,7 +225,7 @@ jobs:
           ./gradlew check -si
 
   build_macos_arm64:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies.
@@ -242,9 +242,29 @@ jobs:
           name: macos_arm64
           path: |
             native_build/install/libcurl*
+
+  test_macos_arm64:
+    runs-on: macos-15
+    needs: build_macos_arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Gradle Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos_arm64
+          path: native_build/install/
+      - name: "Check"
+        run: |
+          ./gradlew check -si
+
   collate:
     runs-on: ubuntu-22.04
-    needs: [ build_linux_x64-gnu, test_linux_x64-gnu, build_linux_x64-musl, test_linux_x64-musl, build_linux_arm64-gnu, build_linux_arm64-musl, test_linux_arm64-gnu, build_windows_x64, test_windows_x64, build_macos_x64, test_macos_x64, build_macos_arm64 ]
+    needs: [ build_linux_x64-gnu, test_linux_x64-gnu, build_linux_x64-musl, test_linux_x64-musl, build_linux_arm64-gnu, build_linux_arm64-musl, test_linux_arm64-gnu, build_windows_x64, test_windows_x64, build_macos_x64, test_macos_x64, build_macos_arm64, test_macos_arm64 ]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -240,7 +240,7 @@ jobs:
           path: native_build/install/
       - name: "Check"
         run: |
-          cat /Users/runner/.m2/settings.xml
+          find -depth 3 /Users/runner/hostedtoolcache
           ./gradlew check -si
 
   build_macos_arm64:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -240,7 +240,6 @@ jobs:
           path: native_build/install/
       - name: "Check"
         run: |
-          find -depth 3 /Users/runner/hostedtoolcache
           ./gradlew check -si
 
   build_macos_arm64:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -205,24 +205,24 @@ jobs:
           path: |
             native_build/install/libcurl*
 
-  test_macos_x64:
-    runs-on: macos-15
-    needs: build_macos_x64
-    steps:
-      - uses: actions/checkout@v4
-      - name: Gradle Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle
-          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: gradle-
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos_x64
-          path: native_build/install/
-      - name: "Check"
-        run: |
-          ./gradlew check -si
+#  test_macos_x64:
+#    runs-on: macos-15
+#    needs: build_macos_x64
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Gradle Cache
+#        uses: actions/cache@v4
+#        with:
+#          path: ~/.gradle
+#          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+#          restore-keys: gradle-
+#      - uses: actions/download-artifact@v4
+#        with:
+#          name: macos_x64
+#          path: native_build/install/
+#      - name: "Check"
+#        run: |
+#          ./gradlew check -si
 
   build_macos_arm64:
     runs-on: macos-15
@@ -264,7 +264,7 @@ jobs:
 
   collate:
     runs-on: ubuntu-22.04
-    needs: [ build_linux_x64-gnu, test_linux_x64-gnu, build_linux_x64-musl, test_linux_x64-musl, build_linux_arm64-gnu, build_linux_arm64-musl, test_linux_arm64-gnu, build_windows_x64, test_windows_x64, build_macos_x64, test_macos_x64, build_macos_arm64, test_macos_arm64 ]
+    needs: [ build_linux_x64-gnu, test_linux_x64-gnu, build_linux_x64-musl, test_linux_x64-musl, build_linux_arm64-gnu, build_linux_arm64-musl, test_linux_arm64-gnu, build_windows_x64, test_windows_x64, build_macos_x64, build_macos_arm64, test_macos_arm64 ]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/java9/build.gradle
+++ b/java9/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(9)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 
@@ -19,4 +19,9 @@ dependencies {
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     compileOnly 'org.jetbrains:annotations:24.0.1'
+}
+
+
+compileJava {
+    options.compilerArgs += ['--release', '9']
 }

--- a/native_build/Makefile
+++ b/native_build/Makefile
@@ -117,6 +117,8 @@ C_COMPILER=clang
 
 ifeq (x64, $(arch))
 HOST=x86_64-apple-darwin20.6.0
+CMAKE_ARGS=-DCMAKE_OSX_ARCHITECTURES=x86_64
+CFLAGS=--target=x86_64-apple-darwin20.6.0
 QUICTLS_ARGS=darwin64-x86_64
 else
 HOST=aarch64-apple-darwin20.6.0

--- a/native_build/Makefile
+++ b/native_build/Makefile
@@ -490,7 +490,7 @@ $(curl4j_build): $(COMPILER_DEPS) $(libffi_install) $(java_install)
 
 $(libcurl4j_install): $(curl4j_build)
 	set -e
-	mkdir "$(libcurl4j_install)"
+	mkdir -p "$(libcurl4j_install)"
 	# Copy licenses
 	mkdir -p "$(libcurl4j_install)/$(flavour)/$(arch)/licenses/libffi" && cp "$(libffi_build)/LICENSE" "$(libcurl4j_install)/$(flavour)/$(arch)/licenses/libffi/LICENSE"
 ifeq (linux, $(flavour))

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id "org.gradle.toolchains.foojay-resolver-convention" version "0.9.0"
 }
 
 rootProject.name = 'curl4j'

--- a/src/main/c/net_covers1624_curl4j_CURL_Functions.c
+++ b/src/main/c/net_covers1624_curl4j_CURL_Functions.c
@@ -34,12 +34,12 @@ JNIEXPORT jint JNICALL Java_net_covers1624_curl4j_CURL_00024Functions_ncurl_1eas
 }
 
 JNIEXPORT jint JNICALL Java_net_covers1624_curl4j_CURL_00024Functions_ncurl_1easy_1setopt__JJIJ(JNIEnv *env, jclass clazz, jlong func, jlong curl, jint opt, jlong value) {
-    return ((int (*)(uintptr_t, int, uintptr_t)) (uintptr_t) func)((uintptr_t) curl, opt, (uintptr_t) value);
+    return ((int (*)(uintptr_t, int, ...)) (uintptr_t) func)((uintptr_t) curl, opt, (uintptr_t) value);
 }
 
 JNIEXPORT jint JNICALL Java_net_covers1624_curl4j_CURL_00024Functions_ncurl_1easy_1setopt__JJILjava_lang_String_2(JNIEnv *env, jclass clazz, jlong func, jlong curl, jint opt, jstring value) {
     const char *valStr = (*env)->GetStringUTFChars(env, value, NULL);
-    int ret = ((int (*)(uintptr_t, int, const char *)) (uintptr_t) func)((uintptr_t) curl, opt, valStr);
+    int ret = ((int (*)(uintptr_t, int, ...)) (uintptr_t) func)((uintptr_t) curl, opt, valStr);
     (*env)->ReleaseStringUTFChars(env, value, valStr);
     return ret;
 }
@@ -148,7 +148,7 @@ JNIEXPORT jint JNICALL Java_net_covers1624_curl4j_CURL_00024Functions_ncurl_1mul
 }
 
 JNIEXPORT jint JNICALL Java_net_covers1624_curl4j_CURL_00024Functions_ncurl_1multi_1setopt(JNIEnv *env, jclass clazz, jlong func, jlong multi, jint opt, jlong value) {
-    return ((int (*)(uintptr_t, int, uintptr_t)) (uintptr_t) func)((uintptr_t) multi, opt, (uintptr_t) value);
+    return ((int (*)(uintptr_t, int, ...)) (uintptr_t) func)((uintptr_t) multi, opt, (uintptr_t) value);
 }
 
 JNIEXPORT jstring JNICALL Java_net_covers1624_curl4j_CURL_00024Functions_ncurl_1multi_1strerror(JNIEnv *env, jclass clazz, jlong func, jint code) {


### PR DESCRIPTION
- Compile macOS arm64 natively.
- Enable testing for macOS arm64.
- Cross compile macOS x64 on arm64.
- Test macOS x64 under Rosetta.
- Build Java 9 sources with Java 11 and target Java 9.
- Fix varargs curl calls not working correctly on macOS arm64