### PR TITLE
remove asserts from production code

### DIFF
--- a/src/main/java/net/covers1624/curl4j/CURL.java
+++ b/src/main/java/net/covers1624/curl4j/CURL.java
@@ -3146,7 +3146,9 @@ public class CURL {
      */
     @Nullable
     public static String curl_easy_getinfo_String(@NativeType ("CURL *") long curl, @NativeType ("CURLINFO") int opt) {
-        assert (opt & CURLINFO_TYPEMASK) == CURLINFO_STRING;
+        if ((opt & CURLINFO_TYPEMASK) != CURLINFO_STRING) {
+            throw new IllegalArgumentException("Provided 'opt' does not return a string type.");
+        }
 
         try (Memory.Stack stack = Memory.pushStack()) {
             Pointer pointer = stack.mallocPointer();
@@ -3169,7 +3171,10 @@ public class CURL {
      */
     public static long curl_easy_getinfo_long(@NativeType ("CURL *") long curl, @NativeType ("CURLINFO") int opt) {
         boolean isLong = (opt & CURLINFO_TYPEMASK) == CURLINFO_LONG;
-        assert isLong || (opt & CURLINFO_TYPEMASK) == CURLINFO_OFF_T;
+        boolean isOffT = (opt & CURLINFO_TYPEMASK) == CURLINFO_OFF_T;
+        if (!isLong && !isOffT) {
+            throw new IllegalArgumentException("Provided 'opt' does not return a long type.");
+        }
 
         try (Memory.Stack stack = Memory.pushStack()) {
             Pointer pointer = stack.mallocPointer();

--- a/src/main/java/net/covers1624/curl4j/core/Callback.java
+++ b/src/main/java/net/covers1624/curl4j/core/Callback.java
@@ -158,7 +158,9 @@ public abstract class Callback implements AutoCloseable {
 
     // Invoked by JNI in native land, simply forwards the callback through.
     private void ffi_callback(long ret, long args) throws Throwable {
-        assert delegate != null;
+        if (delegate == null) {
+            throw new IllegalStateException("'delegate' must not be null.");
+        }
         try {
             delegate.invoke(ret, args);
         } catch (Throwable ex) {

--- a/src/main/java/net/covers1624/curl4j/core/Callback.java
+++ b/src/main/java/net/covers1624/curl4j/core/Callback.java
@@ -158,9 +158,6 @@ public abstract class Callback implements AutoCloseable {
 
     // Invoked by JNI in native land, simply forwards the callback through.
     private void ffi_callback(long ret, long args) throws Throwable {
-        if (delegate == null) {
-            throw new IllegalStateException("'delegate' must not be null.");
-        }
         try {
             delegate.invoke(ret, args);
         } catch (Throwable ex) {

--- a/src/test/java/net/covers1624/curl4j/CURLTests.java
+++ b/src/test/java/net/covers1624/curl4j/CURLTests.java
@@ -59,6 +59,10 @@ public class CURLTests extends TestBase {
                 assertEquals(200, curl_easy_getinfo_long(curl, CURLINFO_RESPONSE_CODE));
                 assertEquals("127.0.0.1", curl_easy_getinfo_String(curl, CURL.CURLINFO_PRIMARY_IP));
                 assertArrayEquals(data, output.bytes());
+
+                // Invalid opt types for curl_easy_getinfo methods
+                assertThrows(IllegalArgumentException.class, () -> curl_easy_getinfo_long(curl, CURLINFO_PRIMARY_IP));
+                assertThrows(IllegalArgumentException.class, () -> curl_easy_getinfo_String(curl, CURLINFO_RESPONSE_CODE));
             }
         } finally {
             curl_easy_cleanup(curl);


### PR DESCRIPTION
Fixes #22

For testing I extended CURLTests.testDownload() instead of creating a new method in order to not clog up the class.