### PR TITLE
Fix constant value to match official library

### DIFF
--- a/src/main/java/net/covers1624/curl4j/CURL.java
+++ b/src/main/java/net/covers1624/curl4j/CURL.java
@@ -241,7 +241,7 @@ public class CURL {
      * <p>
      * See the <a href="https://curl.se/libcurl/c/CURLOPT_LOW_SPEED_TIME.html">documentation</a>.
      */
-    public static final int CURLOPT_LOW_SPEED_TIME = CURLOPTTYPE_LONG + 19;
+    public static final int CURLOPT_LOW_SPEED_TIME = CURLOPTTYPE_LONG + 20;
 
     /**
      * Set the continuation offset.


### PR DESCRIPTION
According to the official curl.h file, the value of CURLOPT_LOW_SPEED_TIME should be 20 instead of 19